### PR TITLE
Added fix seed command and regex replacement capability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,64 @@
+# $Id: CMakeLists.txt 2018-11-05 D.J. Salvat
+# for building with cmake. For example:
+# $ mkdir g4simple-build
+# $ cd g4simple-build
+# $ cmake -DCMAKE_INSTALL_PREFIX=/path/to/desired/install/ /path/to/g4simple
+# $ make
+# $ make install
+#----------------------------------------------------------------------------
+# Setup the project
+cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+project(g4simple)
+
+#----------------------------------------------------------------------------
+# Find Geant4 package, activating all available UI and Vis drivers by default
+# You can set WITH_GEANT4_UIVIS to OFF via the command line or ccmake/cmake-gui
+# to build a batch mode only executable
+#
+option(WITH_GEANT4_UIVIS "Build with Geant4 UI and Vis drivers" ON)
+if(WITH_GEANT4_UIVIS)
+  find_package(Geant4 REQUIRED ui_all vis_all)
+else()
+  find_package(Geant4 REQUIRED)
+endif()
+
+#----------------------------------------------------------------------------
+# Setup Geant4 include directories and compile definitions
+# Setup include directory for this project
+#
+include(${Geant4_USE_FILE})
+#----------------------------------------------------------------------------
+# Locate sources and headers for this project
+# NB: headers are included so they will show up in IDEs
+#
+file(GLOB sources ${PROJECT_SOURCE_DIR}/*.cc)
+
+#----------------------------------------------------------------------------
+# Add the executable, and link it to the Geant4 libraries
+#
+add_executable(g4simple g4simple.cc ${sources} ${headers})
+target_link_libraries(g4simple ${Geant4_LIBRARIES})
+
+#----------------------------------------------------------------------------
+# Copy all scripts to the build directory, i.e. the directory in which we
+# build B1. This is so that we can run the executable directly because it
+# relies on these scripts being in the current working directory.
+#
+set(G4SIMPLE_SCRIPTS
+  run.mac
+  visualize.mac
+  )
+
+foreach(_script ${G4SIMPLE_SCRIPTS})
+  configure_file(
+    ${PROJECT_SOURCE_DIR}/${_script}
+    ${PROJECT_BINARY_DIR}/${_script}
+    COPYONLY
+    )
+endforeach()
+
+
+#----------------------------------------------------------------------------
+# Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
+#
+install(TARGETS g4simple DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@ plan to add a G4tgrLineProcessor-based geometry input scheme.
 Output: currently specific to the implemented geometry, will be converted 
 to a generic scheme (first ROOT, then JSON tracks, then ultimately maybe HDF5)
 
+Can be built with the supplied makefile for typical use.
+CMakeLists.txt file provided for installing with cmake. 
 
 See similar project by Jing Liu at https://github.com/jintonic/gears


### PR DESCRIPTION
Added command to fix the seed to a particular value.
Kept the existing seed command the same, so macros should
be backwards compatible.

Changed volID assignment to instead take a replacement pattern
to determine the volID to set based on the match. This casts
the replacement string to an int, so it should not break
any existing functionality -- if you use a constant int
for the second argument, it will just be cast to int appropriately
anyway.

One potential issue to address down the line is that the regex replacement does not check whether the user attempts to set it to 0 or -1. This could potentially be added back in to the stepping action when checked in some way.
